### PR TITLE
Add e2e testing GitHub action (fixes #2)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@ In order to streamline the review process, we ask you follow [these guidelines](
 - [ ] Rebase your PR against the latest commit within the target branch
 - [ ] Include steps to verify and test the intended change
 - [ ] Write or update unit tests and/or integration tests to verify your changes
-- [ ] Verify the basic functionality of the plugin by building and running locally via the [end to end testing script](https://github.com/SeisoLLC/zeek-kafka/blob/main/docker/run_end_to_end.sh)
 - [ ] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
 - [ ] Indicate whether or not this is a breaking change
 - [ ] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Run linting
         run: make lint
-  test:
+  e2e:
     strategy:
       matrix:
         platform: [ubuntu-latest]
@@ -30,5 +30,5 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Run testing
-        run: make test
+      - name: Run e2e tests
+        run: make e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - id: cache-docker
+        uses: actions/cache@v2
+        with:
+          path: ~/cache
+          key: ${{ runner.os }}-cache
       - name: Run e2e tests
-        run: make e2e
+        run: |
+          docker load --input ~/cache/docker.tar && \
+          make e2e
+      - name: Update docker cache
+        run: |
+             mkdir -p ~/cache && \
+             images=($(ls -1 docker/containers | awk '{print "zeek-kafka_" $0}')) && \
+             docker save ${images[*]} -o ~/cache/docker.tar || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,10 @@ jobs:
           key: ${{ runner.os }}-cache
       - name: Run e2e tests
         run: |
-          docker load --input ~/cache/docker.tar && \
+          if [[ -f ~/cache/docker.tar ]]; then
+            echo "Loading ~/cache/docker.tar..."
+            docker load --input ~/cache/docker.tar
+          fi && \
           make e2e
       - name: Update docker cache
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Run linting
         run: make lint
+  test:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run testing
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ distclean:
 
 .PHONY: test
 test:
-	make -C tests
+	@cd docker/ && ./run_end_to_end.sh && ./finish_end_to_end.sh
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test:
 .PHONY: e2e
 e2e:
 	cd docker/ && if [[ "$${GITHUB_ACTIONS,,}" == "true" ]]; then \
-	  ./run_end_to_end.sh --data-path="$${RUNNER_TEMP}" && ./finish_end_to_end.sh ; \
+	  ./run_end_to_end.sh --data-path="$${RUNNER_TEMP}" --test-output="$${RUNNER_TEMP}" && ./finish_end_to_end.sh ; \
 	else \
 	  ./run_end_to_end.sh && ./finish_end_to_end.sh ; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ distclean:
 
 .PHONY: test
 test:
-	@make -C tests
+	make -C tests
 
 .PHONY: e2e
 e2e:

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ distclean:
 
 .PHONY: test
 test:
+	@make -C tests
+
+.PHONY: e2e
+e2e:
 	@cd docker/ && ./run_end_to_end.sh && ./finish_end_to_end.sh
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,11 @@ test:
 
 .PHONY: e2e
 e2e:
-	@cd docker/ && ./run_end_to_end.sh && ./finish_end_to_end.sh
+	cd docker/ && if [[ "$${GITHUB_ACTIONS,,}" == "true" ]]; then \
+	  ./run_end_to_end.sh --data-path="$${RUNNER_TEMP}" && ./finish_end_to_end.sh ; \
+	else \
+	  ./run_end_to_end.sh && ./finish_end_to_end.sh ; \
+	fi
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -455,4 +455,3 @@ redef Kafka::kafka_conf = table( ["metadata.broker.list"] = "node1:6667"
 ## Contributing
 
 If you are interested in contributing to this plugin, please see our [CONTRIBUTING.md](CONTRIBUTING.md).
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -126,10 +126,10 @@ testing scripts to be added to a pull request, and subsequently to a test suite.
   
    > The sample pcaps are:
    >  -  https://github.com/zeek/try-zeek/blob/master/manager/static/pcaps/exercise_traffic.pcap
-   >  -  http://downloads.digitalcorpora.org/corpora/network-packet-dumps/2008-nitroba/nitroba.pcap 
+   >  -  http://downloads.digitalcorpora.org/corpora/scenarios/2008-nitroba/nitroba.pcap
    >  -  https://github.com/zeek/try-zeek/raw/master/manager/static/pcaps/ssh.pcap
-   >  -  https://github.com/markofu/pcaps/blob/master/PracticalPacketAnalysis/ppa-capture-files/ftp.pcap?raw=true 
-   >  -  https://github.com/EmpowerSecurityAcademy/wireshark/blob/master/radius_localhost.pcapng?raw=true 
+   >  -  https://github.com/markofu/pcaps/blob/master/PracticalPacketAnalysis/ppa-capture-files/ftp.pcap?raw=true
+   >  -  https://github.com/EmpowerSecurityAcademy/wireshark/blob/master/radius_localhost.pcapng?raw=true
    >  -  https://github.com/kholia/my-pcaps/blob/master/VNC/07-vnc
 
   ###### Parameters

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,18 @@
 version: '2.4'
 services:
   zookeeper:
-    build: containers/zookeeper
+    build:
+      context: containers/zookeeper
+      cache_from:
+        - zeek-kafka_zookeeper:latest
+        - zookeeper:3.4
     image: zeek-kafka_zookeeper:latest
   kafka-1:
-    build: containers/kafka
+    build:
+      context: containers/kafka
+      cache_from:
+        - zeek-kafka_kafka:latest
+        - wurstmeister/kafka:2.12-2.5.0
     image: zeek-kafka_kafka:latest
     depends_on:
       zookeeper:
@@ -15,7 +23,11 @@ services:
       - KAFKA_LISTENERS=PLAINTEXT://kafka-1:9092
       - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-1:9092
   kafka-2:
-    build: containers/kafka
+    build:
+      context: containers/kafka
+      cache_from:
+        - zeek-kafka_kafka:latest
+        - wurstmeister/kafka:2.12-2.5.0
     image: zeek-kafka_kafka:latest
     depends_on:
       zookeeper:
@@ -28,6 +40,9 @@ services:
   zeek:
     build:
       context: containers/zeek
+      cache_from:
+        - zeek-kafka_zeek:latest
+        - centos:8
       args:
         ZEEK_VERSION: "3.2.1"
         LIBRDKAFKA_VERSION: "1.4.2"

--- a/docker/run_end_to_end.sh
+++ b/docker/run_end_to_end.sh
@@ -220,7 +220,7 @@ if [[ "$NO_PCAP" == false ]]; then
     BASE_FILE_NAME=$(basename "${file}")
     DOCKER_DIRECTORY_NAME=${BASE_FILE_NAME//\./_}
 
-    mkdir "${TEST_OUTPUT_PATH}/${DOCKER_DIRECTORY_NAME}" || exit 1
+    mkdir -p "${TEST_OUTPUT_PATH}/${DOCKER_DIRECTORY_NAME}" || exit 1
     echo "MADE ${TEST_OUTPUT_PATH}/${DOCKER_DIRECTORY_NAME}"
 
     # get the offsets in kafka for the provided topic

--- a/docker/run_end_to_end.sh
+++ b/docker/run_end_to_end.sh
@@ -220,7 +220,7 @@ if [[ "$NO_PCAP" == false ]]; then
     BASE_FILE_NAME=$(basename "${file}")
     DOCKER_DIRECTORY_NAME=${BASE_FILE_NAME//\./_}
 
-    mkdir -p "${TEST_OUTPUT_PATH}/${DOCKER_DIRECTORY_NAME}" || exit 1
+    mkdir "${TEST_OUTPUT_PATH}/${DOCKER_DIRECTORY_NAME}" || exit 1
     echo "MADE ${TEST_OUTPUT_PATH}/${DOCKER_DIRECTORY_NAME}"
 
     # get the offsets in kafka for the provided topic

--- a/docker/scripts/download_sample_pcaps.sh
+++ b/docker/scripts/download_sample_pcaps.sh
@@ -90,7 +90,7 @@ if [[ ! -f "${DATA_PATH}"/example-traffic/exercise-traffic.pcap ]]; then
 fi
 
 if [[ ! -f "${DATA_PATH}"/nitroba/nitroba.pcap ]]; then
-  wget http://downloads.digitalcorpora.org/corpora/network-packet-dumps/2008-nitroba/nitroba.pcap -O "${DATA_PATH}"/nitroba/nitroba.pcap
+  wget http://downloads.digitalcorpora.org/corpora/scenarios/2008-nitroba/nitroba.pcap -O "${DATA_PATH}"/nitroba/nitroba.pcap
 fi
 
 if [[ ! -f "${DATA_PATH}"/ssh/ssh.pcap ]]; then


### PR DESCRIPTION
# Summary of the contribution
This adds `make e2e` to run our e2e tests, and adds a github action which runs `make e2e` on PRs to `main`.

This builds on the GitHub actions introduced in #1

## Prereq:
- [x] #13

## Testing
1. Run `make e2e` locally
2. Observe the github actions output from this PR.

## Checklist
- [X] Confirm that any associated issues are indicated in the pull request title
- [x] Rebase your PR against the latest commit within the target branch
- [X] Include steps to verify and test the intended change
- [X] Write or update unit tests and/or integration tests to verify your changes
- [X] Verify the basic functionality of the plugin by building and running locally via the [end to end testing script](https://github.com/SeisoLLC/zeek-kafka/blob/main/docker/run_end_to_end.sh)
- [X] Indicate whether or not this is a breaking change
- [X] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)