### PR TITLE
Change zkg.meta version to main

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -5,7 +5,7 @@ script_dir = build/scripts/Seiso/Kafka
 build_command = ./configure --with-librdkafka=%(LIBRDKAFKA_ROOT)s && make
 test_command = ( cd tests && btest -d )
 plugin_dir = build
-version = 0.3.0
+version = main
 depends =
   zeek >=3.0.0
   zkg >=2.0


### PR DESCRIPTION
# Summary of the contribution
This changes the zkg.meta version to `main`.

## Testing
`./docker/run_end_to_end.sh` and ensure it works.

## Checklist
- [X] Confirm that any associated issues are indicated in the pull request title
- [X] Rebase your PR against the latest commit within the target branch
- [X] Include steps to verify and test the intended change
- [X] Write or update unit tests and/or integration tests to verify your changes
- [X] Verify the basic functionality of the plugin by building and running locally via the [end to end testing script](https://github.com/SeisoLLC/zeek-kafka/blob/main/docker/run_end_to_end.sh)
- [X] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [X] Indicate whether or not this is a breaking change
- [X] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)