### PR TITLE
Make test output path configurable

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -219,6 +219,7 @@ Other scripts may then be used to do your testing, for example running:
 --skip-docker-build             [OPTIONAL] Skip build of zeek docker machine.
 --no-pcaps                      [OPTIONAL] Do not run pcaps.
 --data-path                     [OPTIONAL] The pcap data path. Default: ./data
+--test-output                   [OPTIONAL] The test output path. Default: ./test_output/DATETIME
 --kafka-topic                   [OPTIONAL] The kafka topic name to use. Default: zeek
 --partitions                    [OPTIONAL] The number of kafka partitions to create. Default: 2
 --plugin-version                [OPTIONAL] The plugin version. Default: the current branch name

--- a/docker/run_end_to_end.sh
+++ b/docker/run_end_to_end.sh
@@ -26,6 +26,7 @@ function help {
   echo "USAGE"
   echo "    --skip-docker-build             [OPTIONAL] Skip build of zeek docker machine."
   echo "    --data-path                     [OPTIONAL] The pcap data path. Default: ./data"
+  echo "    --test-output                   [OPTIONAL] The test output path. Default: ./test_output/DATETIME"
   echo "    --kafka-topic                   [OPTIONAL] The kafka topic to consume from. Default: zeek"
   echo "    --partitions                    [OPTIONAL] The number of kafka partitions to create. Default: 2"
   echo "    --plugin-version                [OPTIONAL] The plugin version. Default: the current branch name"
@@ -113,8 +114,19 @@ for i in "$@"; do
   #
   # DATA_PATH
   #
+  #   --data-path
+  #
     --data-path=*)
       DATA_PATH="${i#*=}"
+      shift # past argument=value
+    ;;
+  #
+  # TEST_OUTPUT_PATH
+  #
+  #   --test-output
+  #
+    --test-output=*)
+      TEST_OUTPUT_PATH="${i#*=}"
       shift # past argument=value
     ;;
   #


### PR DESCRIPTION
# Summary of the contribution
This adds `--test-output=` to `run_end_to_end.sh`, which is required for #9 

## Testing
Run `run_end_to_end.sh`, using different `--test-output=` or none, and observe the logs and outputs.

## Checklist
- [x] Confirm that any associated issues are indicated in the pull request title
- [x] Rebase your PR against the latest commit within the target branch
- [x] Include steps to verify and test the intended change
- [x] Write or update unit tests and/or integration tests to verify your changes
- [x] Verify the basic functionality of the plugin by building and running locally via the [end to end testing script](https://github.com/SeisoLLC/zeek-kafka/blob/main/docker/run_end_to_end.sh)
- [x] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [x] Indicate whether or not this is a breaking change
- [x] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)