### PR TITLE
Version pin the github action runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [Ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
   e2e:
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [Ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -21,7 +21,7 @@ set -E # errtrap
 set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
-MISSING_COPYRIGHT=$(find "${DIR}" \( -path "${DIR}/.git" -or                     \
+MISSING_COPYRIGHT=$(find "${DIR}" \( -path "${DIR}/.git" -or \
                  -path "${DIR}/.github" \) -prune -false -or \
          \(      -not -name ".*"                             \
             -and -not -name "*.yml"                          \
@@ -36,7 +36,7 @@ MISSING_COPYRIGHT=$(find "${DIR}" \( -path "${DIR}/.git" -or                    
                  -type f                                     \
          \)                                                  \
                  -print0 |                                   \
-  xargs -0 grep --files-without-match 'Copyright 2020-2.* Zeek-Kafka$')
+  xargs -0 grep --files-without-match 'Copyright 2020-2.* Zeek-Kafka$' || true)
 
 if [[ "${MISSING_COPYRIGHT}" ]]; then
   echo "The following files are missing the Zeek-Kafka copyright"


### PR DESCRIPTION
# Summary of the contribution
Per [github actions notifications](https://github.com/actions/virtual-environments/issues/1816), `-latest` is changing to `20.04` soon.  We should both version pin and test this change before it happens.

## Testing
Look at CI logs

## Checklist
- [x] Confirm that any associated issues are indicated in the pull request title
- [x] Rebase your PR against the latest commit within the target branch
- [x] Include steps to verify and test the intended change
- [x] Write or update unit tests and/or integration tests to verify your changes
- [x] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [x] Indicate whether or not this is a breaking change
- [x] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)