### PR TITLE
Fix LIBRDKAFKA_ROOT default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A Zeek log writer that sends logging output to Kafka, providing a convenient mea
         librdkafka ~1.4.2
 
     Proceed? [Y/n]
-    zeek/seisollc/zeek-kafka asks for LIBRDKAFKA_ROOT (Path to librdkafka installation tree) ? [/usr/local/lib]
+    zeek/seisollc/zeek-kafka asks for LIBRDKAFKA_ROOT (Path to librdkafka installation tree) ? [/usr/local]
     Saved answers to config file: /home/jonzeolla/.zkg/config
     Running unit tests for "zeek/seisollc/zeek-kafka"
     all 10 tests successful

--- a/configure.plugin
+++ b/configure.plugin
@@ -22,7 +22,7 @@
 plugin_usage()
 {
   cat <<EOF
-  --with-librdkafka=PATH	 path to librdkafka
+  --with-librdkafka=PATH	 path to librdkafka install root
   --with-openssl=PATH      path to OpenSSL install root
 EOF
 }

--- a/zkg.meta
+++ b/zkg.meta
@@ -12,4 +12,4 @@ depends =
 external_depends =
   librdkafka ~1.4.2-RC1
 user_vars =
-  LIBRDKAFKA_ROOT [/usr/local/lib] "Path to librdkafka installation tree"
+  LIBRDKAFKA_ROOT [/usr/local] "Path to librdkafka installation tree root"


### PR DESCRIPTION
# Summary of the contribution
Currently the `LIBRDKAFKA_ROOT` default is `/usr/local/lib`, but it should be `/usr/local` as that is the root path where `librdkafka` files diverge (into `include/` and `lib/`)

## Testing
`make e2e`

## Checklist
- [X] Confirm that any associated issues are indicated in the pull request title
- [X] Rebase your PR against the latest commit within the target branch
- [X] Include steps to verify and test the intended change
- [X] Write or update unit tests and/or integration tests to verify your changes
- [X] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [X] Indicate whether or not this is a breaking change
- [X] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)