### PR TITLE
Add versioning

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,31 @@
+---
+name: "Prerelease"
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+
+jobs:
+  distribute:
+    name: Distribute
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Setup the dependencies
+        run: |
+          python -m pip install --upgrade pipenv
+          pipenv install --dev
+      - name: Publish the release to GitHub
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ github.ref }} release
+          draft: false
+          prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+---
+name: "Release"
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  distribute:
+    name: Distribute
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Setup the dependencies
+        run: |
+          python -m pip install --upgrade pipenv
+          pipenv install --dev
+      - name: Publish the release to GitHub
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ github.ref }} release
+          draft: false
+          prerelease: false

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,20 @@
+# Maintainers Guide
+
+This guide is intended for maintainers — anybody with commit access to the `zeek-kafka` repository.
+
+## Releases
+
+All `zeek-kafka` releases first have a release candidate prior to being promoted to general availability.
+
+In order to create a release, you must have `pipenv` and `python3` installed, and then run the following commands, where `$TYPE` is one of `major`, `minor`, `patch`, `build`, or `release`.
+
+```bash
+TYPE=major
+REMOTE=origin
+
+git checkout main  # Releases should always come from main
+pipenv run invoke version $TYPE
+git push --atomic $REMOTE $(git branch --show-current) $(git tag --points-at HEAD)
+```
+
+The previous commands result in a tagged commit containing updated version references in `zkg.meta` and `README.md` (as defined in `setup.cfg`) being pushed to GitHub, at which point GitHub actions performs the remaining release actions based on `.github/workflows/release.yml` and `.github/workflows/prerelease.yml`.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,17 @@
+<!--
+  Copyright 2020-2021 Zeek-Kafka
+  Copyright 2015-2020 The Apache Software Foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 # Maintainers Guide
 
 This guide is intended for maintainers — anybody with commit access to the `zeek-kafka` repository.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,5 @@
 <!--
   Copyright 2020-2021 Zeek-Kafka
-  Copyright 2015-2020 The Apache Software Foundation
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+bumpversion = "*"
+gitpython = "*"
+invoke = "*"
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,70 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "fa60813059bfb3ea196995439f77cf4724eeb1effea00d163ab15b7729b6c12d"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {
+        "bump2version": {
+            "hashes": [
+                "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410",
+                "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.1"
+        },
+        "bumpversion": {
+            "hashes": [
+                "sha256:4ba55e4080d373f80177b4dabef146c07ce73c7d1377aabf9d3c3ae1f94584a6",
+                "sha256:4eb3267a38194d09f048a2179980bb4803701969bff2c85fa8f6d1ce050be15e"
+            ],
+            "index": "pypi",
+            "version": "==0.6.0"
+        },
+        "gitdb": {
+            "hashes": [
+                "sha256:6c4cc71933456991da20917998acbe6cf4fb41eeaab7d6d67fbc05ecd4c865b0",
+                "sha256:96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005"
+            ],
+            "markers": "python_version >= '3.4'",
+            "version": "==4.0.7"
+        },
+        "gitpython": {
+            "hashes": [
+                "sha256:29fe82050709760081f588dd50ce83504feddbebdc4da6956d02351552b1c135",
+                "sha256:ee24bdc93dce357630764db659edaf6b8d664d4ff5447ccfeedd2dc5c253f41e"
+            ],
+            "index": "pypi",
+            "version": "==3.1.17"
+        },
+        "invoke": {
+            "hashes": [
+                "sha256:7e44d98a7dc00c91c79bac9e3007276965d2c96884b3c22077a9f04042bd6d90",
+                "sha256:da7c2d0be71be83ffd6337e078ef9643f41240024d6b2659e7b46e0b251e339f",
+                "sha256:f0c560075b5fb29ba14dad44a7185514e94970d1b9d57dcd3723bec5fed92650"
+            ],
+            "index": "pypi",
+            "version": "==1.5.0"
+        },
+        "smmap": {
+            "hashes": [
+                "sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182",
+                "sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==4.0.0"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ A Zeek log writer that sends logging output to Kafka, providing a convenient mea
 1. Install the plugin using `zkg install`.
 
     ```
-    $ zkg install seisollc/zeek-kafka --version main
+    $ zkg install seisollc/zeek-kafka --version 0.4.0
     The following packages will be INSTALLED:
-      zeek/seisollc/zeek-kafka (main)
+      zeek/seisollc/zeek-kafka (0.4.0)
 
     Verify the following REQUIRED external dependencies:
     (Ensure their installation on all relevant systems before proceeding):
-      from zeek/seisollc/zeek-kafka (main):
+      from zeek/seisollc/zeek-kafka (0.4.0):
         librdkafka ~1.4.2
 
     Proceed? [Y/n]
@@ -62,7 +62,7 @@ A Zeek log writer that sends logging output to Kafka, providing a convenient mea
 
 
     Installing "zeek/seisollc/zeek-kafka"........
-    Installed "zeek/seisollc/zeek-kafka" (main)
+    Installed "zeek/seisollc/zeek-kafka" (0.4.0)
     Loaded "zeek/seisollc/zeek-kafka"
     ```
 
@@ -70,7 +70,7 @@ A Zeek log writer that sends logging output to Kafka, providing a convenient mea
 
     ```
     $ zeek -N Seiso::Kafka
-    Seiso::Kafka - Writes logs to Kafka (dynamic, version 0.3.0)
+    Seiso::Kafka - Writes logs to Kafka (dynamic, version 0.4.0)
     ```
 
 ### Manual Installation
@@ -104,7 +104,7 @@ These instructions could also be helpful if you were interested in distributing 
 
     ```
     $ zeek -N Seiso::Kafka
-    Seiso::Kafka - Writes logs to Kafka (dynamic, version 0.3.0)
+    Seiso::Kafka - Writes logs to Kafka (dynamic, version 0.4.0)
     ```
 
 ## Activation
@@ -456,3 +456,13 @@ redef Kafka::kafka_conf = table( ["metadata.broker.list"] = "node1:6667"
 ## Contributing
 
 If you are interested in contributing to this plugin, please see our [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+
+### Releases
+
+In order to create a release, run the following commands, where `$TYPE` is one of `major`, `minor`, or `patch`.
+
+```bash
+git checkout main
+pipenv run invoke release $TYPE
+git push --atomic origin $(git branch --show-current) $(git describe --tags)
+```

--- a/README.md
+++ b/README.md
@@ -459,10 +459,10 @@ If you are interested in contributing to this plugin, please see our [CONTRIBUTI
 
 ### Releases
 
-In order to create a release, run the following commands, where `$TYPE` is one of `major`, `minor`, or `patch`.
+In order to create a release, run the following commands, where `$TYPE` is one of `major`, `minor`, `patch`, `build`, or `release`.
 
 ```bash
-git checkout main
-pipenv run invoke release $TYPE
+git checkout main  # Releases should always come from main
+pipenv run invoke version $TYPE
 git push --atomic origin $(git branch --show-current) $(git describe --tags)
 ```

--- a/README.md
+++ b/README.md
@@ -456,13 +456,3 @@ redef Kafka::kafka_conf = table( ["metadata.broker.list"] = "node1:6667"
 ## Contributing
 
 If you are interested in contributing to this plugin, please see our [CONTRIBUTING.md](.github/CONTRIBUTING.md).
-
-### Releases
-
-In order to create a release, run the following commands, where `$TYPE` is one of `major`, `minor`, `patch`, `build`, or `release`.
-
-```bash
-git checkout main  # Releases should always come from main
-pipenv run invoke version $TYPE
-git push --atomic origin $(git branch --show-current) $(git describe --tags)
-```

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -27,11 +27,13 @@ MISSING_COPYRIGHT=$(find "${DIR}" \( -path "${DIR}/.git" -or \
             -and -not -name "*.yml"                          \
             -and -not -name "*.pcap"                         \
             -and -not -name "*.pcapng"                       \
-            -and -not -name "requirements*.txt"              \
+            -and -not -name "COPYING"                        \
             -and -not -name "Dockerfile"                     \
+            -and -not -name "Pipfile*"                       \
             -and -not -name "output"                         \
             -and -not -name "random.seed"                    \
-            -and -not -name "COPYING"                        \
+            -and -not -name "requirements*.txt"              \
+            -and -not -name "setup.cfg"                      \
             -and -not -name "zkg.meta"                       \
                  -type f                                     \
          \)                                                  \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[bumpversion]
+current_version = 0.4.0
+commit_message = "Automatically generated release {new_version}"
+commit = True
+tag = True
+push = True
+
+[bumpversion:file:README.md]
+
+[bumpversion:file:zkg.meta]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,22 @@
 [bumpversion]
 current_version = 0.4.0
 commit_message = "Automatically generated release {new_version}"
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
+serialize =
+	{major}.{minor}.{patch}-{release}{build}
+	{major}.{minor}.{patch}
 commit = True
 tag = True
 push = True
+
+[bumpversion:part:release]
+optional_value = ga
+first_value = rc
+values =
+	rc
+	ga
+
+[bumpversion:part:build]
 
 [bumpversion:file:README.md]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ values =
 	ga
 
 [bumpversion:part:build]
+first_value = 1
 
 [bumpversion:file:README.md]
 

--- a/tasks.py
+++ b/tasks.py
@@ -5,7 +5,6 @@ Task execution tool & library
 
 #
 #  Copyright 2020-2021 Zeek-Kafka
-#  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,7 @@
 Task execution tool & library
 """
 
+import re
 import sys
 from logging import basicConfig, getLogger
 from pathlib import Path
@@ -32,14 +33,14 @@ except git.InvalidGitRepositoryError:
 
 
 @task
-def release(_c, release_type):
+def version(_c, version_type):
     """Make a new release of zeek-kafka"""
     if REPO.head.is_detached:
         LOG.error("In detached HEAD state, refusing to release")
         sys.exit(1)
 
-    if release_type not in ["major", "minor", "patch"]:
-        LOG.error("Please provide a release type of major, minor, or patch")
+    if version_type not in ["major", "minor", "patch", "build", "release"]:
+        LOG.error("Please provide a release type of major, minor, patch, build, or release")
         sys.exit(1)
 
-    bumpversion([release_type])
+    bumpversion([version_type])

--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,23 @@
 Task execution tool & library
 """
 
+#
+#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2015-2020 The Apache Software Foundation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 import re
 import sys
 from logging import basicConfig, getLogger

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Task execution tool & library
+"""
+
+import sys
+from logging import basicConfig, getLogger
+from pathlib import Path
+
+import json
+import git
+from bumpversion.cli import main as bumpversion
+from invoke import task
+
+LOG_FORMAT = json.dumps(
+    {
+        "timestamp": "%(asctime)s",
+        "namespace": "%(name)s",
+        "loglevel": "%(levelname)s",
+        "message": "%(message)s",
+    }
+)
+
+basicConfig(level="INFO", format=LOG_FORMAT)
+LOG = getLogger("zeek-kafka.invoke")
+
+CWD = Path(".").absolute()
+try:
+    REPO = git.Repo(CWD)
+except git.InvalidGitRepositoryError:
+    REPO = None
+
+
+@task
+def release(_c, release_type):
+    """Make a new release of zeek-kafka"""
+    if REPO.head.is_detached:
+        LOG.error("In detached HEAD state, refusing to release")
+        sys.exit(1)
+
+    if release_type not in ["major", "minor", "patch"]:
+        LOG.error("Please provide a release type of major, minor, or patch")
+        sys.exit(1)
+
+    bumpversion([release_type])

--- a/zkg.meta
+++ b/zkg.meta
@@ -5,7 +5,7 @@ script_dir = build/scripts/Seiso/Kafka
 build_command = ./configure --with-librdkafka=%(LIBRDKAFKA_ROOT)s && make
 test_command = cd tests && btest -d
 plugin_dir = build
-version = main
+version = 0.4.0
 depends =
   zeek >=4.0.0
   zkg >=2.0


### PR DESCRIPTION
# Summary of the contribution
This adds semi-automated versioning to the project.  The general flow is that every release is a rc by default (major, minor, or patch).  We can increment the build number with `pipenv run invoke version build`, and you can promote a given rc to a final release with `pipenv run invoke version release`.

## Testing
Run the following where `$TYPE` is one of `major`, `minor`, `patch`, `build`, or `release`.  Ensure the scenario described in the summary holds true in your local environment.
```bash
pipenv run invoke version $TYPE
```

## Checklist
- [X] Confirm that any associated issues are indicated in the pull request title
- [X] Rebase your PR against the latest commit within the target branch
- [X] Include steps to verify and test the intended change
- [X] Write or update unit tests and/or integration tests to verify your changes
- [X] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [X] Indicate whether or not this is a breaking change
- [X] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)