### PR TITLE
update years, move the zkg meta librdkakfa dep to 1.4.2 release from RC

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/MAINTAINER
+++ b/MAINTAINER
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020-2021 Zeek-Kafka
+  Copyright 2020-2022 Zeek-Kafka
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-   Copyright 2020-2021 Zeek-Kafka
+   Copyright 2020-2022 Zeek-Kafka
 
    The Initial Developer of this project, which was copied from, derived from,
    or inspired by Apache Metron, is The Apache Software Foundation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020-2021 Zeek-Kafka
+  Copyright 2020-2022 Zeek-Kafka
   Copyright 2015-2020 The Apache Software Foundation
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/cmake/FindLibRDKafka.cmake
+++ b/cmake/FindLibRDKafka.cmake
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmake/FindOpenSSL.cmake
+++ b/cmake/FindOpenSSL.cmake
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/configure.plugin
+++ b/configure.plugin
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020-2021 Zeek-Kafka
+  Copyright 2020-2022 Zeek-Kafka
   Copyright 2015-2020 The Apache Software Foundation
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/containers/kafka/Dockerfile
+++ b/docker/containers/kafka/Dockerfile
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Package
+#  Copyright 2020-2022 Zeek-Package
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/containers/zeek/Dockerfile.centos:8
+++ b/docker/containers/zeek/Dockerfile.centos:8
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/containers/zeek/Dockerfile.ubuntu:20.04
+++ b/docker/containers/zeek/Dockerfile.ubuntu:20.04
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/containers/zeek/Makefile
+++ b/docker/containers/zeek/Makefile
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/containers/zookeeper/Dockerfile
+++ b/docker/containers/zookeeper/Dockerfile
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Package
+#  Copyright 2020-2022 Zeek-Package
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/finish_end_to_end.sh
+++ b/docker/finish_end_to_end.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
-#  Copyright 2020-2021 The Apache Software Foundation
+#  Copyright 2020-2022 Zeek-Kafka
+#  Copyright 2020-2022 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/docker/in_docker_scripts/build_plugin.sh
+++ b/docker/in_docker_scripts/build_plugin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/in_docker_scripts/configure_plugin.sh
+++ b/docker/in_docker_scripts/configure_plugin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/in_docker_scripts/process_data_file.sh
+++ b/docker/in_docker_scripts/process_data_file.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2010
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/run_end_to_end.sh
+++ b/docker/run_end_to_end.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/analyze_results.sh
+++ b/docker/scripts/analyze_results.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/docker_execute_build_plugin.sh
+++ b/docker/scripts/docker_execute_build_plugin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/docker_execute_configure_plugin.sh
+++ b/docker/scripts/docker_execute_configure_plugin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/docker_execute_create_topic_in_kafka.sh
+++ b/docker/scripts/docker_execute_create_topic_in_kafka.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/docker_execute_process_data_file.sh
+++ b/docker/scripts/docker_execute_process_data_file.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/docker_execute_shell.sh
+++ b/docker/scripts/docker_execute_shell.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/docker_run_consume_kafka.sh
+++ b/docker/scripts/docker_run_consume_kafka.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/docker_run_get_offset_kafka.sh
+++ b/docker/scripts/docker_run_get_offset_kafka.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/download_sample_pcaps.sh
+++ b/docker/scripts/download_sample_pcaps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/print_results.sh
+++ b/docker/scripts/print_results.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/scripts/split_kafka_output_by_log.sh
+++ b/docker/scripts/split_kafka_output_by_log.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2143,SC1083,SC2002,SC2126
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/Seiso/Kafka/__load__.zeek
+++ b/scripts/Seiso/Kafka/__load__.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/Seiso/Kafka/logs-to-kafka.zeek
+++ b/scripts/Seiso/Kafka/logs-to-kafka.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/__load__.zeek
+++ b/scripts/__load__.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/init.zeek
+++ b/scripts/init.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/KafkaWriter.cc
+++ b/src/KafkaWriter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Zeek-Kafka
+ * Copyright 2020-2022 Zeek-Kafka
  * Copyright 2015-2020 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/KafkaWriter.h
+++ b/src/KafkaWriter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Zeek-Kafka
+ * Copyright 2020-2022 Zeek-Kafka
  * Copyright 2015-2020 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Zeek-Kafka
+ * Copyright 2020-2022 Zeek-Kafka
  * Copyright 2015-2020 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Zeek-Kafka
+ * Copyright 2020-2022 Zeek-Kafka
  * Copyright 2015-2020 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/TaggedJSON.cc
+++ b/src/TaggedJSON.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Zeek-Kafka
+ * Copyright 2020-2022 Zeek-Kafka
  * Copyright 2015-2020 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/TaggedJSON.h
+++ b/src/TaggedJSON.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Zeek-Kafka
+ * Copyright 2020-2022 Zeek-Kafka
  * Copyright 2015-2020 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/events.bif
+++ b/src/events.bif
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/kafka.bif
+++ b/src/kafka.bif
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/kafka_const.bif
+++ b/src/kafka_const.bif
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tasks.py
+++ b/tasks.py
@@ -4,7 +4,7 @@ Task execution tool & library
 """
 
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/Scripts/diff-remove-timestamps
+++ b/tests/Scripts/diff-remove-timestamps
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/Scripts/get-zeek-env
+++ b/tests/Scripts/get-zeek-env
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/btest.cfg
+++ b/tests/btest.cfg
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/l2s-l2e-no-overlap.zeek
+++ b/tests/kafka/l2s-l2e-no-overlap.zeek
@@ -1,5 +1,5 @@
 # 
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/l2s-set-l2e-set.zeek
+++ b/tests/kafka/l2s-set-l2e-set.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/l2s-set-l2e-unset.zeek
+++ b/tests/kafka/l2s-set-l2e-unset.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/l2s-unset-l2e-set.zeek
+++ b/tests/kafka/l2s-unset-l2e-set.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/l2s-unset-l2e-unset.zeek
+++ b/tests/kafka/l2s-unset-l2e-unset.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/resolved-topic-config.zeek
+++ b/tests/kafka/resolved-topic-config.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/resolved-topic-default.zeek
+++ b/tests/kafka/resolved-topic-default.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/resolved-topic-override-and-config.zeek
+++ b/tests/kafka/resolved-topic-override-and-config.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/resolved-topic-override-only.zeek
+++ b/tests/kafka/resolved-topic-override-only.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/send-all-active-logs-l2e-set.zeek
+++ b/tests/kafka/send-all-active-logs-l2e-set.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/send-all-active-logs-l2e-unset.zeek
+++ b/tests/kafka/send-all-active-logs-l2e-unset.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/send-all-active-logs-l2s-set-l2e-set.zeek
+++ b/tests/kafka/send-all-active-logs-l2s-set-l2e-set.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/send-all-active-logs-l2s-set-l2e-unset.zeek
+++ b/tests/kafka/send-all-active-logs-l2s-set-l2e-unset.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/kafka/show-plugin.zeek
+++ b/tests/kafka/show-plugin.zeek
@@ -1,5 +1,5 @@
 #
-#  Copyright 2020-2021 Zeek-Kafka
+#  Copyright 2020-2022 Zeek-Kafka
 #  Copyright 2015-2020 The Apache Software Foundation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/zkg.meta
+++ b/zkg.meta
@@ -10,6 +10,6 @@ depends =
   zeek >=4.0.0
   zkg >=2.0
 external_depends =
-  librdkafka ~1.4.2-RC1
+  librdkafka ~1.4.2
 user_vars =
   LIBRDKAFKA_ROOT [/usr/local] "Path to librdkafka installation tree root"


### PR DESCRIPTION
librdkafka zkg to 1.4.2

*Thank you for submitting a contribution to the zeek-kafka writer plugin.

In order to streamline the review process, we ask you follow [these guidelines](https://github.com/SeisoLLC/zeek-kafka/blob/main/.github/CONTRIBUTING.md) and complete the following template.*

# Summary of the contribution
Remove the RC from the librdkafka zkg meta requires
Update copyright dates to 2022
...

## Testing
...
Docker

## Checklist
- [-] Confirm that any associated issues are indicated in the pull request title
- [x] Rebase your PR against the latest commit within the target branch
- [x] Include steps to verify and test the intended change
- [-] Write or update unit tests and/or integration tests to verify your changes
- [-] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [-] Indicate whether or not this is a breaking change
- [-] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)
