### PR TITLE
Updated cmake_minimum_required to 3.15 to match Zeek 6.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(ZeekPlugin_Kafka)
 include(ZeekPlugin)
 find_package(LibRDKafka)


### PR DESCRIPTION
# Summary of the contribution

Updates `cmake_minimum_required` to `3.15`.  This is needed when building zeek-kafka in the `zeek/zeek:6.1.0` (latest) Docker image, otherwise this compatibility error is raised:

```
CMake Error at /usr/local/zeek/share/zeek/cmake/ZeekPlugin.cmake:139 (message):
  Plugin requires CMake 3.0 which is less than Zeek's requirement (3.15.0).
  Please update cmake_minimum_required VERSION to 3.15 or higher.
Call Stack (most recent call first):
  CMakeLists.txt:20 (include)
```

This issue assumes that this change is ok to make for all supported Zeek versions, and that the plugin aspires to support latest Zeek 6.1.0 and beyond.

## Testing

Built this `Dockerfile`:

```
FROM zeek/zeek:6.1.0

RUN apt-get update && \
    apt-get install -y cmake libssl-dev librdkafka-dev libpcap-dev g++

RUN zkg install --force https://github.com/javabrett/zeek-kafka.git --version cmake-version --user-var librdkafka_root=/usr
```

## Checklist
- [x] Confirm that any associated issues are indicated in the pull request title
- [x] Rebase your PR against the latest commit within the target branch
- [x] Include steps to verify and test the intended change
- [ ] Write or update unit tests and/or integration tests to verify your changes
- [ ] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [ ] Indicate whether or not this is a breaking change
- [ ] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)
