### PR TITLE
Fixed version tag specifier for zkg install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A Zeek log writer that sends logging output to Kafka, providing a convenient mea
 1. Install the plugin using `zkg install`.
 
     ```
-    $ zkg install seisollc/zeek-kafka --version 1.2.0
+    $ zkg install seisollc/zeek-kafka --version v1.2.0
     The following packages will be INSTALLED:
       zeek/seisollc/zeek-kafka (1.2.0)
 


### PR DESCRIPTION
# Summary of the contribution

`zkg` install command wouldn't work for me per the docs:

```
   7 | >>> RUN zkg install --force seisollc/zeek-kafka --version 1.2.0 --user-var librdkafka_root=/usr

9.663 error: invalid package "seisollc/zeek-kafka": no such commit, branch, or version tag: "1.2.0"
```

Version string needs to exactly match the tag name, so `v1.2.0` for latest release.

```
#6 0.144 + zkg install --force seisollc/zeek-kafka --version v1.2.0 --user-var librdkafka_root=/usr
#6 87.36 Running unit tests for "zeek/seisollc/zeek-kafka"
#6 87.36 Installing "zeek/seisollc/zeek-kafka"
#6 111.2 Installed "zeek/seisollc/zeek-kafka" (v1.2.0)
#6 111.2 Loaded "zeek/seisollc/zeek-kafka"
#6 111.2 + zeek -N Seiso::Kafka
#6 111.5 Seiso::Kafka - Writes logs to Kafka (dynamic, version 0.3.0)
```

Hopefully this change doesn't upset bump-version.

## Testing
...

## Checklist
- [x] Confirm that any associated issues are indicated in the pull request title
- [x] Rebase your PR against the latest commit within the target branch
- [x] Include steps to verify and test the intended change
- [ ] Write or update unit tests and/or integration tests to verify your changes
- [ ] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [ ] Indicate whether or not this is a breaking change
- [ ] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)
