### PR TITLE
TaggedJSON: Rename Describe() to DescribeTagged()

### DIFF
--- a/src/KafkaWriter.cc
+++ b/src/KafkaWriter.cc
@@ -235,8 +235,9 @@ bool KafkaWriter::DoWrite(int num_fields, const threading::Field *const *fields,
 
     // format the log entry
     if (BifConst::Kafka::tag_json) {
-      dynamic_cast<threading::formatter::TaggedJSON *>(formatter)->Describe(
-          &buff, num_fields, fields, vals, additional_message_values);
+      dynamic_cast<threading::formatter::TaggedJSON *>(formatter)
+          ->DescribeTagged(&buff, num_fields, fields, vals,
+                           additional_message_values);
     } else {
       formatter->Describe(&buff, num_fields, fields, vals);
     }

--- a/src/TaggedJSON.cc
+++ b/src/TaggedJSON.cc
@@ -25,7 +25,7 @@ TaggedJSON::TaggedJSON(std::string sn, MsgThread* t, JSON::TimeFormat tf): JSON(
 TaggedJSON::~TaggedJSON()
 {}
 
-bool TaggedJSON::Describe(ODesc* desc, int num_fields, const Field* const* fields, Value** vals, std::map<std::string,std::string> &const_vals) const
+bool TaggedJSON::DescribeTagged(ODesc* desc, int num_fields, const Field* const* fields, Value** vals, std::map<std::string,std::string> &const_vals) const
 {
     desc->AddRaw("{");
 

--- a/src/TaggedJSON.h
+++ b/src/TaggedJSON.h
@@ -42,8 +42,10 @@ class TaggedJSON : public JSON {
 public:
   TaggedJSON(std::string stream_name, MsgThread *t, JSON::TimeFormat tf);
   virtual ~TaggedJSON();
-  virtual bool Describe(ODesc *desc, int num_fields, const Field *const *fields,
-                        Value **vals, std::map<std::string, std::string> &const_vals) const;
+
+  bool DescribeTagged(ODesc *desc, int num_fields, const Field *const *fields,
+                      Value **vals,
+                      std::map<std::string, std::string> &const_vals) const;
 
 private:
   std::string stream_name;


### PR DESCRIPTION
# Summary of the contribution

Newer compilers (e.g. clang 19) produce the following warning:

    TaggedJSON.h:45:16: warning: 'zeek::threading::formatter::TaggedJSON::Describe' hides overloaded virtual functions [-Woverloaded-virtual]

Rename the method to avoid this warning.

## Testing

Just compile testing. We include this plugin as smoke test within Zeek's CI and these warnings started appearing after switching to Debian 13.0 / trixie.


## Checklist
- [ ] Confirm that any associated issues are indicated in the pull request title
- [ ] Rebase your PR against the latest commit within the target branch
- [x] Include steps to verify and test the intended change
- [ ] Write or update unit tests and/or integration tests to verify your changes
- [ ] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [ ] Indicate whether or not this is a breaking change
- [ ] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)
