### PR TITLE
Version number reported doesn't match the actual version number.

### DIFF
--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -31,7 +31,8 @@ zeek::plugin::Configuration Plugin::Configure()
     zeek::plugin::Configuration config;
     config.name = "Seiso::Kafka";
     config.description = "Writes logs to Kafka";
-    config.version.major = 0;
-    config.version.minor = 3;
+    config.version.major = 1;
+    config.version.minor = 2;
+    config.version.patch = 0;
     return config;
 }


### PR DESCRIPTION
# Summary of the contribution
The version number reported by the plugin doesn't match the actual version number of the plugin. This can cause confusion when listing loaded plugins through `Zeek -N` and in logs. This contribution fixes that by updating the reported version number.

## Checklist
- [X] Confirm that any associated issues are indicated in the pull request title
- [X] Rebase your PR against the latest commit within the target branch
- [ ] Include steps to verify and test the intended change
- [ ] Write or update unit tests and/or integration tests to verify your changes
- [X] Run shellcheck against any new or updated shell scripts, indicating the reasoning behind any disabled checks
- [ ] Indicate whether or not this is a breaking change
- [X] Ensure that any new dependencies are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)
